### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     #   run: npm ci
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         pre: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
         name: clabroche/docker-registry/vanessalanquetin


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore